### PR TITLE
Fix threaded renderer not working.

### DIFF
--- a/src/libretro/libretro-common/rthreads/rsemaphore.c
+++ b/src/libretro/libretro-common/rthreads/rsemaphore.c
@@ -117,6 +117,21 @@ bool ssem_trywait(ssem_t *semaphore)
    return positive;
 }
 
+int ssem_get(ssem_t *semaphore)
+{
+   int val = 0;
+   if (!semaphore)
+      return 0;
+
+   slock_lock(semaphore->mutex);
+
+   val = semaphore->value;
+
+   slock_unlock(semaphore->mutex);
+
+   return val;
+}
+
 void ssem_signal(ssem_t *semaphore)
 {
    if (!semaphore)

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -443,7 +443,6 @@ static void render_frame(void)
          {
             if(using_opengl) deinitialize_opengl_renderer();
 #endif
-            GPU::InitRenderer(false);
             current_renderer = CurrentRenderer::Software;
 #ifdef HAVE_OPENGL
          }
@@ -630,6 +629,7 @@ bool retro_load_game(const struct retro_game_info *info)
    rom_path = std::string(info->path);
    save_path = std::string(retro_saves_directory) + std::string(1, PLATFORM_DIR_SEPERATOR) + std::string(game_name) + ".sav";
 
+   GPU::InitRenderer(false);
    GPU::SetRenderSettings(false, video_settings);
    NDS::SetConsoleType(0);
    NDS::LoadROM(rom_path.c_str(), save_path.c_str(), direct_boot);

--- a/src/libretro/platform.cpp
+++ b/src/libretro/platform.cpp
@@ -88,7 +88,9 @@ namespace Platform
    void Semaphore_Reset(Semaphore *sema)
    {
    #ifdef HAVE_THREADS
-      ssem_wait((ssem_t*)sema);
+      while (ssem_get((ssem_t*)sema) > 0) {
+        ssem_trywait((ssem_t*)sema);
+      }
    #endif
    }
 


### PR DESCRIPTION
Hi guys. For starters, thank you very much for this port, it works really great.

It looks like threaded rendering is broken, because during the first frame there is a call to `GPU::InitRenderer(false);` which basically resets the releated settings.

Here I moved the code as it is in the upstream Qt frontend, with `GPU::InitRenderer` followed by `GPU::SetRenderSettings`.

This caused a deadlock, because it looks like our semaphores are behaving a bit differently. Let me know if you know a smarter way to reset the semaphores and I'll update the pull request accordingly.

I've also ported the core to Android in my branch, but it's relying on a couple of pull requests which I pushed upstream, so as soon as these are merged I'll contribute all the code here.