### PR TITLE
Update Makefile to avoid "ARMJIT_Linkage.S" removal on "make clean".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ endif
 
 include Makefile.common
 
-OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o) $(SOURCES_S:.s=.o)
+OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o) $(SOURCES_S:.S=.o)
 
 CXXFLAGS += -std=gnu++14
 
@@ -430,7 +430,7 @@ endif
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(fpic) -c $(OBJOUT)$@ $<
 
-%.o: %.s
+%.o: %.S
 	$(CC) $(CFLAGS) $(fpic) -x assembler-with-cpp $(ASFLAGS) -c $(OBJOUT)$@ $<
 
 clean:


### PR DESCRIPTION
Atm a `make clean` will delete the file "ARMJIT_Linkage.S" because of the renaming that happened not long ago: 298b958 and future build will fail because of the missing file.

The "CMakeLists.txt" was modified accordingly but not the "Makefile", I'm not a dev so I hope this is a proper fix, it works on my machine at least, tested on both Windows 10 (mingw64) and a Linux Mint VM :p 