### PR TITLE
Add ability to disable Wifi support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 STATIC_LINKING := 0
 AR             := ar
 
+HAVE_NEON      := 0
+HAVE_OPENGL    := 0
+HAVE_OPENGLES3 := 0
+HAVE_THREADS   := 0
+HAVE_WIFI      := 1
+
 SPACE :=
 SPACE := $(SPACE) $(SPACE)
 BACKSLASH :=

--- a/Makefile.common
+++ b/Makefile.common
@@ -83,6 +83,10 @@ SOURCES_C += $(CORE_DIR)/libretro-common/rthreads/rthreads.c \
 DEFINES += -DHAVE_THREADS
 endif
 
+ifeq ($(HAVE_WIFI), 1)
+DEFINES += -DHAVE_WIFI
+endif
+
 # TODO: re-add when neon is implemented upstream
 ifeq ($(HAVE_NEON), 1)
 # SOURCES_CXX += $(MELON_DIR)/GPU2D_Neon.cpp

--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -20,7 +20,6 @@
 
 #include "GPU3D.h"
 #include "Platform.h"
-#include <thread>
 
 namespace GPU3D
 {

--- a/src/libretro/platform.cpp
+++ b/src/libretro/platform.cpp
@@ -24,6 +24,16 @@
 #include "libui_sdl/LAN_Socket.h"
 #endif
 
+#ifndef HAVE_WIFI
+#define SO_REUSEADDR 0
+#define SO_BROADCAST 0
+#define socket(domain, type, protocol) NULL
+#define bind(sockfd, addr, addrlen) -1
+#define setsockopt(sockfd, level, optname, optval, optlen) -1
+#define sendto(sockfd, buf, len, flags, dest_addr, addrlen) 0
+#define recvfrom(sockfd, buf, len, flags, src_addr, addrlen) 0
+#endif
+
 #ifdef HAVE_THREADS
 #include <stdlib.h>
 
@@ -133,27 +143,38 @@ namespace Platform
 
    Mutex* Mutex_Create()
    {
+   #ifdef HAVE_THREADS
       return (Mutex*)slock_new();
+   #endif
+      return NULL;
    }
 
    void Mutex_Free(Mutex* mutex)
    {
+   #ifdef HAVE_THREADS
       slock_free((slock_t*)mutex);
+   #endif
    }
 
    void Mutex_Lock(Mutex* mutex)
    {
+   #ifdef HAVE_THREADS
       slock_lock((slock_t*)mutex);
+   #endif
    }
 
    void Mutex_Unlock(Mutex* mutex)
    {
+   #ifdef HAVE_THREADS
       slock_unlock((slock_t*)mutex);
+   #endif
    }
 
    bool Mutex_TryLock(Mutex* mutex)
    {
+   #ifdef HAVE_THREADS
       slock_try_lock((slock_t*)mutex);
+   #endif
       return true;
    }
 


### PR DESCRIPTION
Some background: in the effort of building this core using the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk), there are some modifications I would like to propose. 🙂 

First, according to [this issue](https://github.com/WebAssembly/wasi-libc/issues/71), wasi-libc does not implement networking functions (might be in the future, but it looks like it's still not the case). To get around that, I added an `HAVE_WIFI` flag, enabled by default. When set to `0`, `#defines` are added to mock those functions, returning error codes when applicable.

Then, some threading adjustements. the wasi-libc library is raising a build error whenever a single `thread`-related include is detected. I removed one that did not seem to be used, and I skip mutexes manipulation when threads are disabled.

With those modifications, build is successful on both Unix and WASM platforms: is it enough to assume that those changes are non-breaking?