### PR TITLE
Honor melonds_boot_directly default value

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -55,7 +55,7 @@ enum CurrentRenderer
 
 static CurrentRenderer current_renderer = CurrentRenderer::None;
 
-bool direct_boot = false;
+bool direct_boot = true;
 
 static void fallback_log(enum retro_log_level level, const char *fmt, ...)
 {


### PR DESCRIPTION
As per the definition of  `melonds_boot_directly` (`Boot game directly; enabled|disabled`), the game should start by default instead of showing the menu. Here's a quick fix to honor this default value. :slightly_smiling_face: 