### PR TITLE
Fix hybrid screen layout for software renderer

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -472,11 +472,11 @@ static void render_frame(void)
       if(screen_layout_data.hybrid)
       {
          unsigned primary = screen_layout_data.displayed_layout == ScreenLayout::HybridTop ? 0 : 1;
-         unsigned secondary = screen_layout_data.displayed_layout == ScreenLayout::HybridTop ? 1 : 0;
 
-         copy_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][primary], screen_layout_data.top_screen_offset, true);
-         copy_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][secondary], screen_layout_data.bottom_screen_offset, false);
-
+         copy_hybrid_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][primary], ScreenId::Primary);
+         copy_hybrid_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][0], ScreenId::Top);
+         copy_hybrid_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][1], ScreenId::Bottom);
+         
          if(cursor_enabled(&input_state))
             draw_cursor(&screen_layout_data, input_state.touch_x, input_state.touch_y);
 
@@ -485,9 +485,9 @@ static void render_frame(void)
       else
       {
          if(screen_layout_data.enable_top_screen)
-            copy_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][0], screen_layout_data.top_screen_offset, false);
+            copy_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][0], screen_layout_data.top_screen_offset);
          if(screen_layout_data.enable_bottom_screen)
-            copy_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][1], screen_layout_data.bottom_screen_offset, false);
+            copy_screen(&screen_layout_data, GPU::Framebuffer[frontbuf][1], screen_layout_data.bottom_screen_offset);
 
          if(cursor_enabled(&input_state) && current_screen_layout != ScreenLayout::TopOnly)
             draw_cursor(&screen_layout_data, input_state.touch_x, input_state.touch_y);

--- a/src/libretro/screenlayout.h
+++ b/src/libretro/screenlayout.h
@@ -23,6 +23,14 @@ enum ScreenLayout
    HybridBottom = 7,
 };
 
+
+enum ScreenId
+{
+    Primary = 0,
+    Top = 1,
+    Bottom = 2,
+};
+
 struct ScreenLayoutData
 {
     bool enable_top_screen;

--- a/src/libretro/utils.cpp
+++ b/src/libretro/utils.cpp
@@ -7,60 +7,71 @@ int32_t Clamp(int32_t value, int32_t min, int32_t max)
    return std::max(min, std::min(max, value));
 }
 
-void copy_screen(ScreenLayoutData *data, uint32_t* src, unsigned offset, bool primary)
+void copy_screen(ScreenLayoutData *data, uint32_t* src, unsigned offset)
 {
-   if (data->hybrid)
+   if (data->direct_copy)
    {
-      if (primary)
+      memcpy((uint32_t *)data->buffer_ptr + offset, src, data->screen_width * data->screen_height * data->pixel_size);
+   } else {
+      unsigned y;
+      for (y = 0; y < data->screen_height; y++)
       {
-         unsigned buffer_y, buffer_x;
-         unsigned x, y, pixel;
-         uint32_t pixel_data;
-         unsigned buffer_height = data->screen_height * data->hybrid_ratio;
-         unsigned buffer_width = data->screen_width * data->hybrid_ratio;
+         memcpy((uint16_t *)data->buffer_ptr + offset + (y * data->screen_width * data->pixel_size),
+            src + (y * data->screen_width), data->screen_width * data->pixel_size);
+      }
+   }
+}
 
-         for (buffer_y = 0; buffer_y < buffer_height; buffer_y++)
+void copy_hybrid_screen(ScreenLayoutData *data, uint32_t* src, ScreenId screen_id)
+{
+   if (screen_id == ScreenId::Primary)
+   {
+      unsigned buffer_y, buffer_x;
+      unsigned x, y, pixel;
+      uint32_t pixel_data;
+      unsigned buffer_height = data->screen_height * data->hybrid_ratio;
+      unsigned buffer_width = data->screen_width * data->hybrid_ratio;
+
+      for (buffer_y = 0; buffer_y < buffer_height; buffer_y++)
+      {
+         y = buffer_y / data->hybrid_ratio;
+         for (buffer_x = 0; buffer_x < buffer_width; buffer_x++)
          {
-            y = buffer_y / data->hybrid_ratio;
-            for (buffer_x = 0; buffer_x < buffer_width; buffer_x++)
+            x = buffer_x / data->hybrid_ratio;
+
+            pixel_data = *(uint32_t*)(src + (y * data->screen_width) + x);
+
+            for (pixel = 0; pixel < data->hybrid_ratio; pixel++)
             {
-               x = buffer_x / data->hybrid_ratio;
-
-               pixel_data = *(uint32_t*)(src + (y * data->screen_width) + x);
-
-               for (pixel = 0; pixel < data->hybrid_ratio; pixel++)
-               {
-                  *(uint32_t *)(data->buffer_ptr + (buffer_y * data->buffer_stride / 2) + pixel * 2 + (buffer_x * 2)) = pixel_data;
-               }
+               *(uint32_t *)(data->buffer_ptr + (buffer_y * data->buffer_stride / 2) + pixel * 2 + (buffer_x * 2)) = pixel_data;
             }
          }
       }
-      else
+   }
+   else if (screen_id == ScreenId::Top)
+   {
+      unsigned y;
+      for (y = 0; y < data->screen_height; y++)
       {
-         unsigned y;
-         for (y = 0; y < data->screen_height; y++)
-         {
-            memcpy((uint16_t *)data->buffer_ptr
-               // X
-               + ((data->screen_width * data->hybrid_ratio * 2) + (data->hybrid_ratio % 2 == 0 ? data->hybrid_ratio : ((data->hybrid_ratio / 2) * 4)))
-               // Y
-               + ((y + (data->screen_height * (data->hybrid_ratio - 1))) * data->buffer_stride / 2),
-               src + (y * data->screen_width), (data->screen_width) * data->pixel_size);
-         }
+         memcpy((uint16_t *)data->buffer_ptr
+            // X
+            + ((data->screen_width * data->hybrid_ratio * 2) + (data->hybrid_ratio % 2 == 0 ? data->hybrid_ratio : ((data->hybrid_ratio / 2) * 4)))
+            // Y
+            + (y * data->buffer_stride / 2),
+            src + (y * data->screen_width), (data->screen_width) * data->pixel_size);
       }
    }
-   else
+   else if (screen_id == ScreenId::Bottom)
    {
-      if (data->direct_copy)
+      unsigned y;
+      for (y = 0; y < data->screen_height; y++)
       {
-         memcpy((uint32_t *)data->buffer_ptr + offset, src, data->screen_width * data->screen_height * data->pixel_size);
-      } else {
-         unsigned y;
-         for (y = 0; y < data->screen_height; y++)
-         {
-            memcpy((uint16_t *)data->buffer_ptr + offset + (y * data->screen_width * data->pixel_size),
-               src + (y * data->screen_width), data->screen_width * data->pixel_size);
-         }
+         memcpy((uint16_t *)data->buffer_ptr
+            // X
+            + ((data->screen_width * data->hybrid_ratio * 2) + (data->hybrid_ratio % 2 == 0 ? data->hybrid_ratio : ((data->hybrid_ratio / 2) * 4)))
+            // Y
+            + ((y + (data->screen_height * (data->hybrid_ratio - 1))) * data->buffer_stride / 2),
+            src + (y * data->screen_width), (data->screen_width) * data->pixel_size);
       }
    }
 }

--- a/src/libretro/utils.h
+++ b/src/libretro/utils.h
@@ -12,6 +12,7 @@
 #endif
 
 int32_t Clamp(int32_t value, int32_t min, int32_t max);
-void copy_screen(ScreenLayoutData *data, uint32_t* src, unsigned offset, bool primary);
+void copy_screen(ScreenLayoutData *data, uint32_t* src, unsigned offset);
+void copy_hybrid_screen(ScreenLayoutData *data, uint32_t* src, ScreenId screen_id);
 void draw_cursor(ScreenLayoutData *data, int32_t x, int32_t y);
 #endif


### PR DESCRIPTION
This will allow the software renderer hybrid mode to behave the same as in the standalone, i.e. showing both top and bottom screens with a scaled primary screen to the left.