### PR TITLE
Enable DSi support in libretro port.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -31,6 +31,7 @@ endif
 
 SOURCES_CXX := $(MELON_DIR)/NDS.cpp \
                     $(MELON_DIR)/AREngine.cpp \
+                    $(MELON_DIR)/ARCodeFile.cpp \
                     $(MELON_DIR)/ARM.cpp \
                     $(MELON_DIR)/ARMInterpreter.cpp \
                     $(MELON_DIR)/ARMInterpreter_ALU.cpp \
@@ -64,6 +65,7 @@ SOURCES_CXX := $(MELON_DIR)/NDS.cpp \
                     $(MELON_DIR)/SPU.cpp \
                     $(MELON_DIR)/Wifi.cpp \
                     $(MELON_DIR)/WifiAP.cpp \
+                    $(MELON_DIR)/frontend/Util_ROM.cpp \
                     $(CORE_DIR)/config.cpp \
                     $(CORE_DIR)/input.cpp \
                     $(CORE_DIR)/libretro.cpp \

--- a/src/Config.h
+++ b/src/Config.h
@@ -65,6 +65,8 @@ extern char DSiSDPath[1024];
 extern int RandomizeMAC;
 extern int AudioBitrate;
 extern int AudioInterp;
+extern int ConsoleType;
+extern int DirectBoot;
 
 #ifdef JIT_ENABLED
 extern int JIT_Enable;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -89,7 +89,6 @@ u64 FrameStartTimestamp;
 int CurCPU;
 
 const s32 kMaxIterationCycles = 64;
-const s32 kIterationCycleMargin = 8;
 
 u32 ARM9ClockShift;
 
@@ -915,7 +914,7 @@ void RelocateSave(const char* path, bool write)
 
 u64 NextTarget()
 {
-    u64 minEvent = UINT64_MAX;
+    u64 ret = SysTimestamp + kMaxIterationCycles;
 
     u32 mask = SchedListMask;
     for (int i = 0; i < Event_MAX; i++)
@@ -923,19 +922,14 @@ u64 NextTarget()
         if (!mask) break;
         if (mask & 0x1)
         {
-            if (SchedList[i].Timestamp < minEvent)
-                minEvent = SchedList[i].Timestamp;
+            if (SchedList[i].Timestamp < ret)
+                ret = SchedList[i].Timestamp;
         }
 
         mask >>= 1;
     }
 
-    u64 max = SysTimestamp + kMaxIterationCycles;
-
-    if (minEvent < max + kIterationCycleMargin)
-        return minEvent;
-
-    return max;
+    return ret;
 }
 
 void RunSystem(u64 timestamp)
@@ -972,6 +966,7 @@ u32 RunFrame()
 
         while (Running && GPU::TotalScanlines==0)
         {
+            // TODO: give it some margin, so it can directly do 17 cycles instead of 16 then 1
             u64 target = NextTarget();
             ARM9Target = target << ARM9ClockShift;
             CurCPU = 0;

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -726,6 +726,7 @@ bool SavestateExists(int slot)
 
 bool LoadState(const char* filename)
 {
+#ifndef __LIBRETRO__
     u32 oldGBACartCRC = GBACart::CartCRC;
 
     // backup
@@ -789,10 +790,13 @@ bool LoadState(const char* filename)
     }
 
     return !failed;
+#endif
+    return false;
 }
 
 bool SaveState(const char* filename)
 {
+#ifndef __LIBRETRO__
     Savestate* state = new Savestate(filename, true);
     if (state->Error)
     {
@@ -814,12 +818,13 @@ bool SaveState(const char* filename)
             NDS::RelocateSave(SRAMPath[ROMSlot_NDS], true);
         }
     }
-
+#endif
     return true;
 }
 
 void UndoStateLoad()
 {
+#ifndef __LIBRETRO__
     if (!SavestateLoaded) return;
 
     // pray that this works
@@ -834,10 +839,12 @@ void UndoStateLoad()
         strncpy(SRAMPath[ROMSlot_NDS], PrevSRAMPath[ROMSlot_NDS], 1024);
         NDS::RelocateSave(SRAMPath[ROMSlot_NDS], false);
     }
+#endif
 }
 
 int ImportSRAM(const char* filename)
 {
+#ifndef __LIBRETRO__
     FILE* file = fopen(filename, "rb");
     fseek(file, 0, SEEK_END);
     u32 size = ftell(file);
@@ -849,6 +856,8 @@ int ImportSRAM(const char* filename)
     int diff = NDS::ImportSRAM(importData, size);
     delete[] importData;
     return diff;
+#endif
+    return 0;
 }
 
 void EnableCheats(bool enable)

--- a/src/libretro/config.cpp
+++ b/src/libretro/config.cpp
@@ -61,6 +61,8 @@ namespace Config
 
     int AudioBitrate = 0;
     int AudioInterp = 0;
+    int ConsoleType = 0;
+    int DirectBoot = 0;
 
     ConfigEntry ConfigFile[] =
     {

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -787,35 +787,60 @@ bool retro_load_game_special(unsigned type, const struct retro_game_info *info, 
 
 size_t retro_serialize_size(void)
 {
-   // Create the dummy savestate
-   void* data = malloc(MAX_SERIALIZE_TEST_SIZE);
-   Savestate* savestate = new Savestate(data, MAX_SERIALIZE_TEST_SIZE, true);
-   NDS::DoSavestate(savestate);
-   // Find the offset to find the current static filesize
-   size_t size = savestate->GetOffset();
-   // Free
-   delete savestate;
-   free(data);
+   if (NDS::ConsoleType == 0)
+   {
+      // Create the dummy savestate
+      void* data = malloc(MAX_SERIALIZE_TEST_SIZE);
+      Savestate* savestate = new Savestate(data, MAX_SERIALIZE_TEST_SIZE, true);
+      NDS::DoSavestate(savestate);
+      // Find the offset to find the current static filesize
+      size_t size = savestate->GetOffset();
+      // Free
+      delete savestate;
+      free(data);
 
-   return size;
+      return size;
+   }
+   else
+   {
+      log_cb(RETRO_LOG_WARN, "Savestates unsupported in DSi mode.\n");
+      return 0;
+   }
+
 }
 
 bool retro_serialize(void *data, size_t size)
 {
-   Savestate* savestate = new Savestate(data, size, true);
-   NDS::DoSavestate(savestate);
-   delete savestate;
+   if (NDS::ConsoleType == 0)
+   {
+      Savestate* savestate = new Savestate(data, size, true);
+      NDS::DoSavestate(savestate);
+      delete savestate;
 
-   return true;
+      return true;
+   }
+   else
+   {
+      log_cb(RETRO_LOG_WARN, "Savestates unsupported in DSi mode.\n");
+      return false;
+   }
 }
 
 bool retro_unserialize(const void *data, size_t size)
 {
-   Savestate* savestate = new Savestate((void*)data, size, false);
-   NDS::DoSavestate(savestate);
-   delete savestate;
+   if (NDS::ConsoleType == 0)
+   {
+      Savestate* savestate = new Savestate((void*)data, size, false);
+      NDS::DoSavestate(savestate);
+      delete savestate;
 
-   return true;
+      return true;
+   }
+   else
+   {
+      log_cb(RETRO_LOG_WARN, "Savestates unsupported in DSi mode.\n");
+      return false;
+   }
 }
 
 void *retro_get_memory_data(unsigned type)

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -180,6 +180,7 @@ void retro_set_environment(retro_environment_t cb)
       { "melonds_jit_literal_optimisations", "JIT Literal optimisations; enabled|disabled" },
       { "melonds_jit_fast_memory", "JIT Fast memory; enabled|disabled" },
 #endif
+      { "melonds_dsi_sdcard", "Enable DSi SD card; disabled|enabled" },
       { "melonds_audio_bitrate", "Audio bitrate; Automatic|10-bit|16-bit" },
       { "melonds_audio_interpolation", "Audio Interpolation; None|Linear|Cosine|Cubic" },
       { 0, 0 }
@@ -454,6 +455,15 @@ static void check_variables(bool init)
    }
 #endif
 
+   var.key = "melonds_dsi_sdcard";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         Config::DSiSDEnable = 1;
+      else
+         Config::DSiSDEnable = 0;
+   }
+
    var.key = "melonds_audio_bitrate";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
@@ -666,6 +676,7 @@ bool retro_load_game(const struct retro_game_info *info)
    strcpy(Config::DSiBIOS9Path, "dsi_bios9.bin");
    strcpy(Config::DSiFirmwarePath, "dsi_firmware.bin");
    strcpy(Config::DSiNANDPath, "dsi_nand.bin");
+   strcpy(Config::DSiSDPath, "dsi_sd_card.bin");
    strcpy(Config::FirmwareUsername, "MelonDS");
 
    struct retro_input_descriptor desc[] = {

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -56,8 +56,6 @@ enum CurrentRenderer
 
 static CurrentRenderer current_renderer = CurrentRenderer::None;
 
-bool direct_boot = true;
-
 static void fallback_log(enum retro_log_level level, const char *fmt, ...)
 {
    (void)level;
@@ -242,7 +240,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 void retro_reset(void)
 {
    NDS::Reset();
-   NDS::LoadROM(rom_path.c_str(), save_path.c_str(), direct_boot);
+   NDS::LoadROM(rom_path.c_str(), save_path.c_str(), Config::DirectBoot);
 }
 
 static void check_variables(bool init)
@@ -266,9 +264,9 @@ static void check_variables(bool init)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "disabled"))
-         direct_boot = false;
+         Config::DirectBoot = 0;
       else
-         direct_boot = true;
+         Config::DirectBoot = 1;
    }
 
    ScreenLayout layout = ScreenLayout::TopBottom;
@@ -763,7 +761,7 @@ bool retro_load_game(const struct retro_game_info *info)
    SPU::SetInterpolation(Config::AudioInterp);
    NDS::SetConsoleType(Config::ConsoleType);
    Frontend::LoadBIOS();
-   NDS::LoadROM(rom_path.c_str(), save_path.c_str(), direct_boot);
+   NDS::LoadROM(rom_path.c_str(), save_path.c_str(), Config::DirectBoot);
 
    (void)info;
 

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -56,7 +56,6 @@ enum CurrentRenderer
 
 static CurrentRenderer current_renderer = CurrentRenderer::None;
 
-int console_mode = 0; // 0 = ds, 1 = dsi
 bool direct_boot = true;
 
 static void fallback_log(enum retro_log_level level, const char *fmt, ...)
@@ -258,9 +257,9 @@ static void check_variables(bool init)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "DSi"))
-         console_mode = 1;
+         Config::ConsoleType = 1;
       else
-         console_mode = 0;
+         Config::ConsoleType = 0;
    }
 
    var.key = "melonds_boot_directly";
@@ -762,8 +761,7 @@ bool retro_load_game(const struct retro_game_info *info)
    GPU::InitRenderer(false);
    GPU::SetRenderSettings(false, video_settings);
    SPU::SetInterpolation(Config::AudioInterp);
-   Config::ConsoleType = console_mode;
-   NDS::SetConsoleType(console_mode);
+   NDS::SetConsoleType(Config::ConsoleType);
    Frontend::LoadBIOS();
    NDS::LoadROM(rom_path.c_str(), save_path.c_str(), direct_boot);
 


### PR DESCRIPTION
Exposes melonds' experimental DSi support. Behaviour is in line with 0.9.3 so direct boot nds games in DSi mode will hang. It will however succesfully boot ds games and dsiware games installed to the nand dump from the home menu when direct boot is disabled.
The DSi SD card is exposed as a toggleable option and is mounted from dsi_sd_card.bin in the system directory.

New firmware requirments:
```
dsi_bios7.bin -> Required
dsi_bios9.bin -> Required
dsi_nand.bin -> Required
dsi_firmware.bin -> Required
dsi_sd_card.bin -> Optional
```
