### PR TITLE
Add screen-gap core option

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -307,7 +307,7 @@ static void check_variables(bool init)
    var.key = "melonds_screen_gap";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-        screen_layout_data.screen_gap = std::stoi(var.value);
+        screen_layout_data.screen_gap_unscaled = std::stoi(var.value);
    }
 
 #ifdef HAVE_OPENGL

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -114,6 +114,18 @@ void retro_set_environment(retro_environment_t cb)
    struct retro_vfs_interface_info vfs_iface_info;
    environ_cb = cb;
 
+   std::string screen_gap = "Screen gap; ";
+
+   static const int MAX_SCREEN_GAP = 192; // arbitrarily choose screen Y res
+
+   for (int i = 0; i <= MAX_SCREEN_GAP; i++)
+   {
+       screen_gap.append(std::to_string(i));
+
+       if (i != MAX_SCREEN_GAP)
+           screen_gap.append("|");
+   }
+
 #ifdef HAVE_OPENGL
    std::string opengl_resolution = "OpenGL Internal Resolution; ";
 
@@ -157,6 +169,7 @@ void retro_set_environment(retro_environment_t cb)
       { "melonds_console_mode", "Console Mode; DS|DSi" },
       { "melonds_boot_directly", "Boot game directly; enabled|disabled" },
       { "melonds_screen_layout", "Screen Layout; Top/Bottom|Bottom/Top|Left/Right|Right/Left|Top Only|Bottom Only|Hybrid Top|Hybrid Bottom" },
+      { "melonds_screen_gap", screen_gap.c_str() },
       { "melonds_hybrid_small_screen", "Hybrid small screen mode; Bottom|Top|Duplicate" },
       { "melonds_swapscreen_mode", "Swap Screen mode; Toggle|Hold" },
 #ifdef HAVE_THREADS
@@ -289,6 +302,12 @@ static void check_variables(bool init)
          layout = ScreenLayout::HybridTop;
       else if (!strcmp(var.value, "Hybrid Bottom"))
          layout = ScreenLayout::HybridBottom;
+   }
+
+   var.key = "melonds_screen_gap";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+        screen_layout_data.screen_gap = std::stoi(var.value);
    }
 
 #ifdef HAVE_OPENGL

--- a/src/libretro/opengl.cpp
+++ b/src/libretro/opengl.cpp
@@ -177,6 +177,7 @@ void setup_opengl_frame_state(void)
 
    float screen_width = (float)screen_layout_data.screen_width;
    float screen_height = (float)screen_layout_data.screen_height;
+   float screen_gap = (float)screen_layout_data.screen_gap;
 
    float top_screen_x = 0.0f;
    float top_screen_y = 0.0f;
@@ -206,10 +207,10 @@ void setup_opengl_frame_state(void)
    switch (screen_layout_data.displayed_layout)
    {
       case ScreenLayout::TopBottom:
-         bottom_screen_y = screen_height;
+         bottom_screen_y = screen_height + screen_gap;
          break;
       case ScreenLayout::BottomTop:
-         top_screen_y = screen_height;
+         top_screen_y = screen_height + screen_gap;
          break;
       case ScreenLayout::LeftRight:
          bottom_screen_x = screen_width;

--- a/src/libretro/screenlayout.cpp
+++ b/src/libretro/screenlayout.cpp
@@ -79,14 +79,14 @@ void update_screenlayout(ScreenLayout layout, ScreenLayoutData *data, bool openg
             data->direct_copy = true;
 
             data->buffer_width = data->screen_width;
-            data->buffer_height = data->screen_height * 2;
+            data->buffer_height = data->screen_height * 2 + data->screen_gap;
             data->buffer_stride = data->screen_width * pixel_size;
 
             data->touch_offset_x = 0;
-            data->touch_offset_y = data->screen_height;
+            data->touch_offset_y = data->screen_height + data->screen_gap;
 
             data->top_screen_offset = 0;
-            data->bottom_screen_offset = data->buffer_width * data->screen_height;
+            data->bottom_screen_offset = data->buffer_width * (data->screen_height + data->screen_gap);
 
             break;
         case ScreenLayout::BottomTop:
@@ -95,13 +95,13 @@ void update_screenlayout(ScreenLayout layout, ScreenLayoutData *data, bool openg
             data->direct_copy = true;
 
             data->buffer_width = data->screen_width;
-            data->buffer_height = data->screen_height * 2;
+            data->buffer_height = data->screen_height * 2 + data->screen_gap;
             data->buffer_stride = data->screen_width * pixel_size;
 
             data->touch_offset_x = 0;
             data->touch_offset_y = 0;
 
-            data->top_screen_offset = data->buffer_width * data->screen_height;
+            data->top_screen_offset = data->buffer_width * (data->screen_height + data->screen_gap);
             data->bottom_screen_offset = 0;
 
             break;

--- a/src/libretro/screenlayout.cpp
+++ b/src/libretro/screenlayout.cpp
@@ -37,6 +37,7 @@ void update_screenlayout(ScreenLayout layout, ScreenLayoutData *data, bool openg
 
     data->screen_width = VIDEO_WIDTH * scale;
     data->screen_height = VIDEO_HEIGHT * scale;
+    data->screen_gap = data->screen_gap_unscaled * scale;
 
     current_screen_layout = layout;
 

--- a/src/libretro/screenlayout.h
+++ b/src/libretro/screenlayout.h
@@ -54,6 +54,8 @@ struct ScreenLayoutData
     unsigned touch_offset_x;
     unsigned touch_offset_y;
 
+    unsigned screen_gap;
+
     bool hybrid;
     SmallScreenLayout hybrid_small_screen;
     unsigned hybrid_ratio;

--- a/src/libretro/screenlayout.h
+++ b/src/libretro/screenlayout.h
@@ -54,6 +54,7 @@ struct ScreenLayoutData
     unsigned touch_offset_x;
     unsigned touch_offset_y;
 
+    unsigned screen_gap_unscaled;
     unsigned screen_gap;
 
     bool hybrid;


### PR DESCRIPTION
Closes #70 

Only implemented for "portrait" orientations (Top/Bottom and Bottom/Top). I think it's debatable whether the gap makes sense for Left/Right, Right/Left and Hybrid modes. Would be not too difficult to add if desired.

Only affects Libretro version--screen gap is already implemented in the standalone version.

I checked that touch input works correctly on a desktop with a mouse. I don't have an Android/iOS build environment, so I can't verify that it works with a real touchscreen input device--this would be good to check, if someone is able. The on-screen "pixel" is correctly bounded by the bottom screen, regardless of the gap size.