### PR TITLE
Fix compilation when threads are disabled

### DIFF
--- a/src/GPU3D_Soft.h
+++ b/src/GPU3D_Soft.h
@@ -20,8 +20,11 @@
 
 #include "GPU3D.h"
 #include "Platform.h"
+
+#ifdef HAVE_THREADS
 #include <thread>
 #include <atomic>
+#endif
 
 namespace GPU3D
 {
@@ -507,8 +510,15 @@ private:
 
     bool Threaded;
     Platform::Thread* RenderThread;
+
+#ifdef HAVE_THREADS
     std::atomic_bool RenderThreadRunning;
     std::atomic_bool RenderThreadRendering;
+#else
+    bool RenderThreadRunning;
+    bool RenderThreadRendering;
+#endif
+
     Platform::Semaphore* Sema_RenderStart;
     Platform::Semaphore* Sema_RenderDone;
     Platform::Semaphore* Sema_ScanlineCount;

--- a/src/teakra/src/apbp.cpp
+++ b/src/teakra/src/apbp.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <atomic>
 #include <mutex>
 #include <utility>
 #include "apbp.h"

--- a/src/teakra/src/apbp.cpp
+++ b/src/teakra/src/apbp.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <mutex>
 #include <utility>
 #include "apbp.h"
 

--- a/src/teakra/src/common_types.h
+++ b/src/teakra/src/common_types.h
@@ -4,6 +4,7 @@
 
 #ifdef HAVE_THREADS
 #include <atomic>
+#include <mutex>
 #else
 namespace std
 {

--- a/src/teakra/src/common_types.h
+++ b/src/teakra/src/common_types.h
@@ -2,6 +2,43 @@
 
 #include <cstdint>
 
+#ifdef HAVE_THREADS
+#include <atomic>
+#else
+namespace std
+{
+    class mutex {};
+    class recursive_mutex {};
+
+    template<typename _Mutex>
+    class lock_guard
+    {
+    public:
+        lock_guard(_Mutex& _) { }
+    };
+
+    template <typename _Tp>
+    struct atomic
+    {
+    public:
+        atomic() {}
+        atomic(_Tp new_value) { this->value = new_value; }
+
+        _Tp exchange(_Tp new_value) 
+        {
+            _Tp old_value = this->value;
+            this->value = new_value; 
+            return old_value;
+        }
+
+        operator bool() { return this->value; }
+
+    private:
+        _Tp value;
+    };
+}
+#endif
+
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
 using u32 = std::uint32_t;

--- a/src/teakra/src/icu.h
+++ b/src/teakra/src/icu.h
@@ -3,7 +3,6 @@
 #include <array>
 #include <bitset>
 #include <functional>
-#include <mutex>
 #include <utility>
 #include "common_types.h"
 

--- a/src/teakra/src/interpreter.h
+++ b/src/teakra/src/interpreter.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <atomic>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>

--- a/src/teakra/src/teakra.cpp
+++ b/src/teakra/src/teakra.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <atomic>
 #include "ahbm.h"
 #include "apbp.h"
 #include "btdmp.h"


### PR DESCRIPTION
Hey!

Still related to the WASI-sdk and [Junie](https://github.com/Namaneo/Junie), here are some modifications to skip `<atomic>` and `<mutex>` includes. For the Teakra part, it is not very elegant to mock the `std` namespace, but allows to have the smallest impact on the original source code.

Feel free to request any change if required!