### PR TITLE
Fix ignored language configuration

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -729,6 +729,7 @@ bool retro_load_game(const struct retro_game_info *info)
    unsigned language = RETRO_LANGUAGE_ENGLISH;
    if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language))
    {
+      Config::RandomizeMAC = true;
       Config::FirmwareOverrideSettings = true;
       
       switch(language)


### PR DESCRIPTION
After recent sync with upstream, language configuration is ignored again. The slightiest change to make it work again is to set `Config::RandomizeMAC` to `true`, which I believe is not harmful.