### PR TITLE
Point CartROM directly at frontend data pointer

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -623,8 +623,13 @@ bool Init()
 
 void DeInit()
 {
+/*
+* Libretro now guarantees an persistant rom buffer provided by the frontend.
+* CartROM cleanup doesnt need to be handled here.
+*/
+#ifndef __LIBRETRO__    
     if (CartROM) delete[] CartROM;
-
+#endif
     if (Cart) delete Cart;
 }
 
@@ -780,8 +785,7 @@ bool LoadROM(const u8* romdata, u32 filelength, const char *sram)
     while (CartROMSize < filelength)
         CartROMSize <<= 1;
 
-    CartROM = new u8[CartROMSize];
-    memcpy(CartROM, romdata, filelength);
+    CartROM = const_cast<u8*>(romdata);
 
     LoadROMCommon(sram);
 

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1409,14 +1409,26 @@ bool Init()
 
 void DeInit()
 {
+/*
+* Libretro now guarantees an persistant rom buffer provided by the frontend.
+* CartROM cleanup doesnt need to be handled here.
+*/
+#ifndef __LIBRETRO__    
     if (CartROM) delete[] CartROM;
+#endif    
     if (Cart) delete Cart;
 }
 
 void Reset()
 {
     CartInserted = false;
+/*
+* Libretro now guarantees an persistant rom buffer provided by the frontend.
+* CartROM cleanup doesnt need to be handled here.
+*/
+#ifndef __LIBRETRO__    
     if (CartROM) delete[] CartROM;
+#endif   
     CartROM = nullptr;
     CartROMSize = 0;
     CartID = 0;
@@ -1703,9 +1715,7 @@ bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct)
     while (CartROMSize < len)
         CartROMSize <<= 1;
 
-    CartROM = new u8[CartROMSize];
-    memset(CartROM, 0, CartROMSize);
-    memcpy(CartROM, romdata, filelength);
+    CartROM = const_cast<u8*>(romdata);
 
     return LoadROMCommon(filelength, sram, direct);
 }


### PR DESCRIPTION
Thanks to Jamiras for pointing out the duplication of the CartROM content on load and the increase in memory used for loading content after the persistent buffer change.

CartROM is now directly wired to the frontend data buffer pointer and the redundant memcpy/memset calls have been removed. This will should speed up loading on slower devices and halve memory used to load content.

