### PR TITLE
Inital attempt at WiFi support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ HAVE_OPENGL    := 0
 HAVE_OPENGLES3 := 0
 HAVE_THREADS   := 0
 HAVE_WIFI      := 1
+HAVE_SLIRP     := 0
 
 SPACE :=
 SPACE := $(SPACE) $(SPACE)
@@ -448,9 +449,10 @@ else
    CC ?= gcc
    TARGET := $(TARGET_NAME)_libretro.dll
    SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
-   LDFLAGS += -lws2_32 -lwinmm -lopengl32
+   LDFLAGS += -lws2_32 -lwinmm -lopengl32 -lslirp
    HAVE_OPENGL=1
    HAVE_THREADS=1
+   HAVE_SLIRP=1
 
    ifeq ($(MSYSTEM),MINGW64)
       CC ?= x86_64-w64-mingw32-gcc

--- a/Makefile.common
+++ b/Makefile.common
@@ -66,6 +66,7 @@ SOURCES_CXX := $(MELON_DIR)/NDS.cpp \
                     $(MELON_DIR)/Wifi.cpp \
                     $(MELON_DIR)/WifiAP.cpp \
                     $(MELON_DIR)/frontend/Util_ROM.cpp \
+                    $(MELON_DIR)/frontend/qt_sdl/LAN_Socket.cpp \
                     $(CORE_DIR)/config.cpp \
                     $(CORE_DIR)/input.cpp \
                     $(CORE_DIR)/libretro.cpp \
@@ -100,6 +101,10 @@ SOURCES_CXX +=  $(MELON_DIR)/GPU_OpenGL.cpp \
                 $(CORE_DIR)/opengl.cpp
 
 DEFINES += -DHAVE_OPENGL -DOGLRENDERER_ENABLED -DCORE
+endif
+
+ifeq ($(HAVE_SLIRP), 1)
+DEFINES += -DHAVE_SLIRP
 endif
 
 ifeq ($(HAVE_THREADS), 1)

--- a/src/libretro/platform.cpp
+++ b/src/libretro/platform.cpp
@@ -23,9 +23,8 @@
 #include <sys/select.h>
 #endif
 
-#ifdef HAVE_PCAP
-#include "libui_sdl/LAN_PCap.h"
-#include "libui_sdl/LAN_Socket.h"
+#ifdef HAVE_SLIRP
+#include "frontend/qt_sdl/LAN_Socket.h"
 #endif
 
 #ifdef HAVE_LIBNX
@@ -360,59 +359,32 @@ namespace Platform
 
    bool LAN_Init()
    {
-#ifdef HAVE_PCAP
-    if (Config::DirectLAN)
-    {
-        if (!LAN_PCap::Init(true))
-            return false;
-    }
-    else
-    {
-        if (!LAN_Socket::Init())
-            return false;
-    }
-
-    return true;
-#else
-   return false;
+#ifdef HAVE_SLIRP
+      return LAN_Socket::Init();
 #endif
    }
 
    void LAN_DeInit()
    {
-      // checkme. blarg
-      //if (Config::DirectLAN)
-      //    LAN_PCap::DeInit();
-      //else
-      //    LAN_Socket::DeInit();
-#ifdef HAVE_PCAP
-      LAN_PCap::DeInit();
+#ifdef HAVE_SLIRP
       LAN_Socket::DeInit();
 #endif
    }
 
    int LAN_SendPacket(u8* data, int len)
    {
-#ifdef HAVE_PCAP
-      if (Config::DirectLAN)
-         return LAN_PCap::SendPacket(data, len);
-      else
-         return LAN_Socket::SendPacket(data, len);
-#else
-      return 0;
+#ifdef HAVE_SLIRP
+      return LAN_Socket::SendPacket(data, len);
 #endif
+      return 0;
    }
 
    int LAN_RecvPacket(u8* data)
    {
-#ifdef HAVE_PCAP
-      if (Config::DirectLAN)
-         return LAN_PCap::RecvPacket(data);
-      else
-         return LAN_Socket::RecvPacket(data);
-#else
-      return 0;
+#ifdef HAVE_SLIRP
+      return LAN_Socket::RecvPacket(data);
 #endif
+      return 0;
    }
 
 #ifdef HAVE_OPENGL


### PR DESCRIPTION
First pass. Linking against a system install of slirp brings in a dependency on glib-2.0. A local build of this will fail to load against the redist packaged libglib-2.0-0.dll in the release config of Retroach due to version mismatches. The redist version is at least a minor revision back.

However, if the build linked libslirp-0.dll and libglib-2.0-0.dll are copied to the retroarch dir it loads correctly and my testing with a nossl patched mario kart ds connects succefully to Wiimmfi and it can be played online without issues.

Getting a correctly linked libslirp is key this working. I see two options for this.

1. Upgrade the ci infrastructure to install slirp(if not already installed) along with upgrading to a compatible glib2.0, package both as part of the redist libs and build the core linking to the system version in line with the changes in this draft pr.
2. Build libslirp as an internal dep within the core and link it that way.

I've attempted an integrated build but I've not been able to make the required changes that the meson build tool does or get the existing makefile setup find the system glib2.0 without hardcoding paths. To avoid any system linking building glib2.0 as a further core bundled dependency would be required bringing in a whole other layer complexity.

Option 1 would be my prefered choice but any input would be appreciated.