### PR TITLE
Revert #142

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -623,13 +623,8 @@ bool Init()
 
 void DeInit()
 {
-/*
-* Libretro now guarantees an persistant rom buffer provided by the frontend.
-* CartROM cleanup doesnt need to be handled here.
-*/
-#ifndef __LIBRETRO__    
     if (CartROM) delete[] CartROM;
-#endif
+
     if (Cart) delete Cart;
 }
 
@@ -785,7 +780,8 @@ bool LoadROM(const u8* romdata, u32 filelength, const char *sram)
     while (CartROMSize < filelength)
         CartROMSize <<= 1;
 
-    CartROM = const_cast<u8*>(romdata);
+    CartROM = new u8[CartROMSize];
+    memcpy(CartROM, romdata, filelength);
 
     LoadROMCommon(sram);
 

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1409,26 +1409,14 @@ bool Init()
 
 void DeInit()
 {
-/*
-* Libretro now guarantees an persistant rom buffer provided by the frontend.
-* CartROM cleanup doesnt need to be handled here.
-*/
-#ifndef __LIBRETRO__    
     if (CartROM) delete[] CartROM;
-#endif    
     if (Cart) delete Cart;
 }
 
 void Reset()
 {
     CartInserted = false;
-/*
-* Libretro now guarantees an persistant rom buffer provided by the frontend.
-* CartROM cleanup doesnt need to be handled here.
-*/
-#ifndef __LIBRETRO__    
     if (CartROM) delete[] CartROM;
-#endif   
     CartROM = nullptr;
     CartROMSize = 0;
     CartID = 0;
@@ -1715,7 +1703,9 @@ bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct)
     while (CartROMSize < len)
         CartROMSize <<= 1;
 
-    CartROM = const_cast<u8*>(romdata);
+    CartROM = new u8[CartROMSize];
+    memset(CartROM, 0, CartROMSize);
+    memcpy(CartROM, romdata, filelength);
 
     return LoadROMCommon(filelength, sram, direct);
 }


### PR DESCRIPTION
Jamiras has pointed out that melonds will alter the content of CartROM here: https://github.com/libretro/melonDS/blob/ff3f661bb54dcb31e2533967aa231d827d2be4b7/src/NDSCart.cpp#L1643-L1655
Since CartROM is directly referencing the pointer supplied by the frontend this alteration is breaking the hashing for cheevos.
It's probably best to roll this back and eat the few extra megabytes to have softpatching and cheevos working simultaneously.
It also fixes #144