### PR TITLE
Fix emscripten compiler crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ else ifneq (,$(findstring qnx,$(platform)))
 else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_emscripten.bc
    fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
+   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/link.T -Wl
 else ifeq ($(platform), vita)
    TARGET := $(TARGET_NAME)_vita.a
    CC = arm-vita-eabi-gcc


### PR DESCRIPTION
`--no-undefined` is not a valid emscripten compiler flag and on new versions of the compiler will cause the compile to fail