### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/libretro/platform.cpp
+++ b/src/libretro/platform.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #define socket_t    int
 #define sockaddr_t  struct sockaddr
 #define closesocket close


### PR DESCRIPTION
INADDR_ANY and INADDR_BROADCAST are defined in netinet/in.h, so this file should be included. Without it, build fails on FreeBSD.
It's actually also needed on Linux, but likely covered by other headers. Nonetheless, since INADDR_ANY is used, it should be included.