### PR TITLE
Core options changes + update to v2

### DIFF
--- a/src/libretro/libretro-common/include/libretro.h
+++ b/src/libretro/libretro-common/include/libretro.h
@@ -283,6 +283,12 @@ enum retro_language
    RETRO_LANGUAGE_HEBREW              = 21,
    RETRO_LANGUAGE_ASTURIAN            = 22,
    RETRO_LANGUAGE_FINNISH             = 23,
+   RETRO_LANGUAGE_INDONESIAN          = 24,
+   RETRO_LANGUAGE_SWEDISH             = 25,
+   RETRO_LANGUAGE_UKRAINIAN           = 26,
+   RETRO_LANGUAGE_CZECH               = 27,
+   RETRO_LANGUAGE_CATALAN_VALENCIA    = 28,
+   RETRO_LANGUAGE_CATALAN             = 29,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -1753,6 +1759,12 @@ enum retro_mod
                                             * the frontend is attempting to call retro_run().
                                             */
 
+#define RETRO_ENVIRONMENT_GET_SAVESTATE_CONTEXT (72 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* int * --
+                                            * Tells the core about the context the frontend is asking for savestate.
+                                            * (see enum retro_savestate_context)
+                                            */
+
 /* VFS functionality */
 
 /* File paths:
@@ -2990,6 +3002,35 @@ enum retro_pixel_format
    RETRO_PIXEL_FORMAT_UNKNOWN  = INT_MAX
 };
 
+enum retro_savestate_context
+{
+   /* Standard savestate written to disk. */
+   RETRO_SAVESTATE_CONTEXT_NORMAL                 = 0,
+
+   /* Savestate where you are guaranteed that the same instance will load the save state.
+    * You can store internal pointers to code or data.
+    * It's still a full serialization and deserialization, and could be loaded or saved at any time. 
+    * It won't be written to disk or sent over the network.
+    */
+   RETRO_SAVESTATE_CONTEXT_RUNAHEAD_SAME_INSTANCE = 1,
+
+   /* Savestate where you are guaranteed that the same emulator binary will load that savestate.
+    * You can skip anything that would slow down saving or loading state but you can not store internal pointers. 
+    * It won't be written to disk or sent over the network.
+    * Example: "Second Instance" runahead
+    */
+   RETRO_SAVESTATE_CONTEXT_RUNAHEAD_SAME_BINARY   = 2,
+
+   /* Savestate used within a rollback netplay feature.
+    * You should skip anything that would unnecessarily increase bandwidth usage.
+    * It won't be written to disk but it will be sent over the network.
+    */
+   RETRO_SAVESTATE_CONTEXT_ROLLBACK_NETPLAY       = 3,
+
+   /* Ensure sizeof() == sizeof(int). */
+   RETRO_SAVESTATE_CONTEXT_UNKNOWN                = INT_MAX
+};
+
 struct retro_message
 {
    const char *msg;        /* Message to be displayed. */
@@ -3460,6 +3501,10 @@ struct retro_core_option_definition
     * ignored */
    const char *default_value;
 };
+
+#ifdef __PS3__
+#undef local
+#endif
 
 struct retro_core_options_intl
 {

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include <libretro.h>
+#include <libretro_core_options.h>
 #include <streams/file_stream.h>
 #include <streams/file_stream_transforms.h>
 #include <file/file_path.h>
@@ -49,6 +50,15 @@ bool toggle_swap_screen = false;
 bool swap_screen_toggled = false;
 
 const int SLOT_1_2_BOOT = 1;
+
+static bool categories_supported = false;
+#ifdef HAVE_OPENGL
+static bool opengl_options = true;
+#endif
+static bool hybrid_options = true;
+#ifdef JIT_ENABLED
+static bool jit_options = true;
+#endif
 
 enum CurrentRenderer
 {
@@ -112,10 +122,103 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.aspect_ratio = (float)screen_layout_data.buffer_width / (float)screen_layout_data.buffer_height;
 }
 
+static bool update_option_visibility(void)
+{
+   struct retro_core_option_display option_display;
+   struct retro_variable var;
+   bool updated = false;
+
+#ifdef HAVE_OPENGL
+   // Show/hide OpenGL core options
+   bool opengl_options_prev = opengl_options;
+
+   opengl_options = true;
+   var.key = "melonds_opengl_renderer";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "disabled"))
+      opengl_options = false;
+
+   if (opengl_options != opengl_options_prev)
+   {
+      option_display.visible = opengl_options;
+
+      option_display.key = "melonds_opengl_resolution";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      option_display.key = "melonds_opengl_better_polygons";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      option_display.key = "melonds_opengl_filtering";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      updated = true;
+   }
+#endif
+
+   // Show/gide Hybrid screen options
+   bool hybrid_options_prev = hybrid_options;
+
+   hybrid_options = true;
+   var.key = "melonds_screen_layout";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && (strcmp(var.value, "Hybrid Top") && strcmp(var.value, "Hybrid Bottom")))
+      hybrid_options = false;
+
+   if (hybrid_options != hybrid_options_prev)
+   {
+      option_display.visible = hybrid_options;
+
+      option_display.key = "melonds_hybrid_small_screen";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+#ifdef HAVE_OPENGL
+      option_display.key = "melonds_hybrid_ratio";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+#endif
+
+      updated = true;
+   }
+
+#ifdef JIT_ENABLED
+   // Show/hide JIT core options
+   bool jit_options_prev = jit_options;
+
+   jit_options = true;
+   var.key = "melonds_jit_enable";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "disabled"))
+      jit_options = false;
+
+   if (jit_options != jit_options_prev)
+   {
+      option_display.visible = jit_options;
+
+      option_display.key = "melonds_jit_block_size";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      option_display.key = "melonds_jit_branch_optimisations";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      option_display.key = "melonds_jit_literal_optimisations";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      option_display.key = "melonds_jit_fast_memory";
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+      updated = true;
+   }
+#endif
+
+   return updated;
+}
+
 void retro_set_environment(retro_environment_t cb)
 {
    struct retro_vfs_interface_info vfs_iface_info;
    environ_cb = cb;
+
+   libretro_set_core_options(environ_cb, &categories_supported);
+
+   struct retro_core_options_update_display_callback update_display_cb;
+   update_display_cb.callback = update_option_visibility;
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK, &update_display_cb);
 
    static const struct retro_system_content_info_override content_overrides[] = {
       {
@@ -127,91 +230,6 @@ void retro_set_environment(retro_environment_t cb)
    };
 
    environ_cb(RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE, (void*)content_overrides);
-
-   std::string screen_gap = "Screen gap; ";
-
-   static const int MAX_SCREEN_GAP = 192; // arbitrarily choose screen Y res
-
-   for (int i = 0; i <= MAX_SCREEN_GAP; i++)
-   {
-       screen_gap.append(std::to_string(i));
-
-       if (i != MAX_SCREEN_GAP)
-           screen_gap.append("|");
-   }
-
-#ifdef HAVE_OPENGL
-   std::string opengl_resolution = "OpenGL Internal Resolution; ";
-
-   static const int MAX_SCALE = 8;
-
-   char temp[100];
-   for(int i = 1; i <= MAX_SCALE; i++)
-   {
-      temp[0] = 0;
-      snprintf(temp, sizeof(temp), "%ix native (%ix%i)", i, VIDEO_WIDTH * i, VIDEO_HEIGHT * i);
-      std::string param = temp;
-
-      opengl_resolution.append(param);
-
-      if(i != MAX_SCALE)
-         opengl_resolution.append("|");
-   }
-#endif
-
-#ifdef JIT_ENABLED
-   std::string jit_blocksize = "JIT block size; ";
-
-   static const int MAX_JIT_BLOCKSIZE = 100;
-   static const int DEFAULT_BLOCK_SIZE = 32;
-
-   jit_blocksize.append(std::to_string(DEFAULT_BLOCK_SIZE) + "|");
-
-   for(int i = 1; i <= MAX_JIT_BLOCKSIZE; i++)
-   {
-      if(i == DEFAULT_BLOCK_SIZE) continue;
-
-      jit_blocksize.append(std::to_string(i));
-
-      if(i != MAX_JIT_BLOCKSIZE)
-         jit_blocksize.append("|");
-   }
-#endif
-
-  static const retro_variable values[] =
-   {
-      { "melonds_console_mode", "Console Mode; DS|DSi" },
-      { "melonds_boot_directly", "Boot game directly; enabled|disabled" },
-      { "melonds_screen_layout", "Screen Layout; Top/Bottom|Bottom/Top|Left/Right|Right/Left|Top Only|Bottom Only|Hybrid Top|Hybrid Bottom" },
-      { "melonds_screen_gap", screen_gap.c_str() },
-      { "melonds_hybrid_small_screen", "Hybrid small screen mode; Bottom|Top|Duplicate" },
-      { "melonds_swapscreen_mode", "Swap Screen mode; Toggle|Hold" },
-      { "melonds_randomize_mac_address", "Randomize MAC address; disabled|enabled" },
-#ifdef HAVE_THREADS
-      { "melonds_threaded_renderer", "Threaded software renderer; disabled|enabled" },
-#endif
-      { "melonds_touch_mode", "Touch mode; disabled|Mouse|Touch|Joystick" },
-#ifdef HAVE_OPENGL
-      { "melonds_hybrid_ratio", "Hybrid ratio (OpenGL only); 2|3" },
-      { "melonds_opengl_renderer", "OpenGL Renderer (Restart); disabled|enabled" },
-      { "melonds_opengl_resolution", opengl_resolution.c_str() },
-      { "melonds_opengl_better_polygons", "OpenGL Improved polygon splitting; disabled|enabled" },
-      { "melonds_opengl_filtering", "OpenGL filtering; nearest|linear" },
-#endif
-#ifdef JIT_ENABLED
-      { "melonds_jit_enable", "JIT Enable (Restart); enabled|disabled" },
-      { "melonds_jit_block_size", jit_blocksize.c_str() },
-      { "melonds_jit_branch_optimisations", "JIT Branch optimisations; enabled|disabled" },
-      { "melonds_jit_literal_optimisations", "JIT Literal optimisations; enabled|disabled" },
-      { "melonds_jit_fast_memory", "JIT Fast memory; enabled|disabled" },
-#endif
-      { "melonds_dsi_sdcard", "Enable DSi SD card; disabled|enabled" },
-      { "melonds_audio_bitrate", "Audio bitrate; Automatic|10-bit|16-bit" },
-      { "melonds_audio_interpolation", "Audio Interpolation; None|Linear|Cosine|Cubic" },
-      { 0, 0 }
-   };
-
-   environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, (void*)values);
 
    if (cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
       log_cb = logging.log;
@@ -549,9 +567,37 @@ static void check_variables(bool init)
          Config::AudioInterp = 0;
    }
 
+   var.key = "melonds_use_fw_settings";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         Config::FirmwareOverrideSettings = true;
+      else if (!strcmp(var.value, "enabled"))
+         Config::FirmwareOverrideSettings = false;
+   }
+
+   var.key = "melonds_language";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "Japanese"))
+         Config::FirmwareLanguage = 0;
+      else if (!strcmp(var.value, "English"))
+         Config::FirmwareLanguage = 1;
+      else if (!strcmp(var.value, "French"))
+         Config::FirmwareLanguage = 2;
+      else if (!strcmp(var.value, "German"))
+         Config::FirmwareLanguage = 3;
+      else if (!strcmp(var.value, "Italian"))
+         Config::FirmwareLanguage = 4;
+      else if (!strcmp(var.value, "Spanish"))
+         Config::FirmwareLanguage = 5;
+   }
+
    input_state.current_touch_mode = new_touch_mode;
 
    update_screenlayout(layout, &screen_layout_data, enable_opengl, swapped_screens);
+
+   update_option_visibility();
 }
 
 static void audio_callback(void)
@@ -746,7 +792,12 @@ static bool _handle_load_game(unsigned type, const struct retro_game_info *info)
    strcpy(Config::DSiFirmwarePath, "dsi_firmware.bin");
    strcpy(Config::DSiNANDPath, "dsi_nand.bin");
    strcpy(Config::DSiSDPath, "dsi_sd_card.bin");
-   strcpy(Config::FirmwareUsername, "MelonDS");
+
+   const char *retro_username;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_USERNAME, &retro_username) && retro_username)
+      strcpy(Config::FirmwareUsername, retro_username);
+   else
+      strcpy(Config::FirmwareUsername, "melonDS");
 
    struct retro_input_descriptor desc[] = {
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "Left" },
@@ -777,38 +828,6 @@ static bool _handle_load_game(unsigned type, const struct retro_game_info *info)
    {
       log_cb(RETRO_LOG_INFO, "XRGB8888 is not supported.\n");
       return false;
-   }
-
-   unsigned language = RETRO_LANGUAGE_ENGLISH;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language))
-   {
-      Config::FirmwareOverrideSettings = true;
-      
-      switch(language)
-      {
-      case RETRO_LANGUAGE_JAPANESE:
-         Config::FirmwareLanguage = 0;
-         break;
-
-      case RETRO_LANGUAGE_FRENCH:
-         Config::FirmwareLanguage = 2;
-         break;
-
-      case RETRO_LANGUAGE_GERMAN:
-         Config::FirmwareLanguage = 3;
-         break;
-
-      case RETRO_LANGUAGE_ITALIAN:
-         Config::FirmwareLanguage = 4;
-         break;
-
-      case RETRO_LANGUAGE_SPANISH:
-         Config::FirmwareLanguage = 5;
-         break;
-
-      default:
-         Config::FirmwareLanguage = 1; // English
-      }
    }
 
    check_variables(true);

--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -1,0 +1,818 @@
+#ifndef LIBRETRO_CORE_OPTIONS_H__
+#define LIBRETRO_CORE_OPTIONS_H__
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_v2_category option_cats_us[] = {
+   {
+      "system",
+      "System",
+      "Change system settings."
+   },
+   {
+      "video",
+      "Video",
+      "Change video settings."
+   },
+   {
+      "audio",
+      "Audio",
+      "Change audio settings."
+   },
+   {
+      "screen",
+      "Screen",
+      "Change screen settings."
+   },
+#ifdef JIT_ENABLED
+   {
+      "cpu",
+      "CPU Emulation",
+      "Change CPU emulation settings."
+   },
+#endif
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
+   {
+      "melonds_console_mode",
+      "Console Mode",
+      NULL,
+      NULL,
+      NULL,
+      "system",
+      {
+         { "DS",  NULL },
+         { "DSi", NULL },
+         { NULL, NULL },
+      },
+      "DS"
+   },
+   {
+      "melonds_boot_directly",
+      "Boot Game Directly",
+      NULL,
+      "Choose if the core should boot the game directly or if it should boot to the DS menu instead (BIOS and firmware files required).",
+      NULL,
+      "system",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "melonds_use_fw_settings",
+      "Use Firmware Settings",
+      NULL,
+      "Use language and username from the DS firmware. When disabled or if firmware file was not found, the username will be provided by the Libretro frontend, if it's empty it will default to 'melonDS'.",
+      NULL,
+      "system",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "melonds_language",
+      "Language",
+      NULL,
+      "Selected language will be used if 'Use Firmware Settings' is disabled or if firmware file was not found.",
+      NULL,
+      "system",
+      {
+         { "Japanese", NULL },
+         { "English",  NULL },
+         { "French",   NULL },
+         { "German",   NULL },
+         { "Italian",  NULL },
+         { "Spanish",  NULL },
+         { NULL, NULL },
+      },
+      "English"
+   },
+   {
+      "melonds_randomize_mac_address",
+      "Randomize MAC Address",
+      NULL,
+      NULL,
+      NULL,
+      "system",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "melonds_dsi_sdcard",
+      "Enable DSi SD Card",
+      NULL,
+      NULL,
+      NULL,
+      "system",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+#ifdef HAVE_THREADS
+   {
+      "melonds_threaded_renderer",
+      "Threaded Software Renderer",
+      NULL,
+      NULL,
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+#endif
+#ifdef HAVE_OPENGL
+   {
+      "melonds_opengl_renderer",
+      "OpenGL Renderer (Restart)",
+      NULL,
+      NULL,
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "melonds_opengl_resolution",
+      "OpenGL Internal Resolution",
+      NULL,
+      NULL,
+      NULL,
+      "video",
+      {
+         { "1x native (256x192)",   NULL },
+         { "2x native (512x384)",   NULL },
+         { "3x native (768x576)",   NULL },
+         { "4x native (1024x768)",  NULL },
+         { "5x native (1280x960)",  NULL },
+         { "6x native (1536x1152)", NULL },
+         { "7x native (1792x1344)", NULL },
+         { "8x native (2048x1536)", NULL },
+         { NULL, NULL },
+      },
+      "1x native (256x192)"
+   },
+   {
+      "melonds_opengl_better_polygons",
+      "OpenGL Improved Polygon Splitting",
+      NULL,
+      NULL,
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "melonds_opengl_filtering",
+      "OpenGL Filtering",
+      NULL,
+      NULL,
+      NULL,
+      "video",
+      {
+         { "nearest", NULL },
+         { "linear",  NULL },
+         { NULL, NULL },
+      },
+      "nearest"
+   },
+#endif
+   {
+      "melonds_audio_bitrate",
+      "Audio Bitrate",
+      NULL,
+      NULL,
+      NULL,
+      "audio",
+      {
+         { "Automatic", NULL },
+         { "10-bit",    NULL },
+         { "16-bit",    NULL },
+         { NULL, NULL },
+      },
+      "Automatic"
+   },
+   {
+      "melonds_audio_interpolation",
+      "Audio Interpolation",
+      NULL,
+      NULL,
+      NULL,
+      "audio",
+      {
+         { "None",   NULL },
+         { "Linear", NULL },
+         { "Cosine", NULL },
+         { "Cubic",  NULL },
+         { NULL, NULL },
+      },
+      "None"
+   },
+   {
+      "melonds_touch_mode",
+      "Touch Mode",
+      NULL,
+      "Choose mode for interactions with the touch screen.",
+      NULL,
+      "screen",
+      {
+         { "Mouse",    NULL },
+         { "Touch",    NULL },
+         { "Joystick", NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "Mouse"
+   },
+   {
+      "melonds_swapscreen_mode",
+      "Swap Screen Mode",
+      NULL,
+      "Choose if the 'Swap screens' button should work on press or on hold.",
+      NULL,
+      "screen",
+      {
+         { "Toggle", NULL },
+         { "Hold",   NULL },
+         { NULL, NULL },
+      },
+      "Toggle"
+   },
+   {
+      "melonds_screen_layout",
+      "Screen Layout",
+      NULL,
+      "Choose how many screens should be displayed and how they should be displayed.",
+      NULL,
+      "screen",
+      {
+         { "Top/Bottom",    NULL },
+         { "Bottom/Top",    NULL },
+         { "Left/Right",    NULL },
+         { "Right/Left",    NULL },
+         { "Top Only",      NULL },
+         { "Bottom Only",   NULL },
+         { "Hybrid Top",    NULL },
+         { "Hybrid Bottom", NULL },
+         { NULL, NULL },
+      },
+      "Top/Bottom"
+   },
+   {
+      "melonds_screen_gap",
+      "Screen Gap",
+      NULL,
+      "Choose how large the gap between the 2 screens should be.",
+      NULL,
+      "screen",
+      {
+         { "0",   NULL },
+         { "1",   NULL },
+         { "8",   NULL },
+         { "64",  NULL },
+         { "90",  NULL },
+         { "128", NULL },
+         { NULL, NULL },
+      },
+      "0"
+   },
+   {
+      "melonds_hybrid_small_screen",
+      "Hybrid Small Screen Mode",
+      NULL,
+      "Choose the position of the small screen when using a 'hybrid' mode, or if it should show both screens.",
+      NULL,
+      "screen",
+      {
+         { "Bottom",    NULL },
+         { "Top",       NULL },
+         { "Duplicate", NULL },
+         { NULL, NULL },
+      },
+      "Bottom"
+   },
+#ifdef HAVE_OPENGL
+   {
+      "melonds_hybrid_ratio",
+      "Hybrid Ratio (OpenGL Only)",
+      NULL,
+      NULL,
+      NULL,
+      "screen",
+      {
+         { "2", NULL },
+         { "3", NULL },
+         { NULL, NULL },
+      },
+      "2"
+   },
+#endif
+#ifdef JIT_ENABLED
+   {
+      "melonds_jit_enable",
+      "JIT Enable (Restart)",
+      NULL,
+      NULL,
+      NULL,
+      "cpu",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "melonds_jit_block_size",
+      "JIT Block Size",
+      NULL,
+      NULL,
+      NULL,
+      "cpu",
+      {
+         { "1",  NULL },
+         { "2",  NULL },
+         { "3",  NULL },
+         { "4",  NULL },
+         { "5",  NULL },
+         { "6",  NULL },
+         { "7",  NULL },
+         { "8",  NULL },
+         { "9",  NULL },
+         { "10", NULL },
+         { "11", NULL },
+         { "12", NULL },
+         { "13", NULL },
+         { "14", NULL },
+         { "15", NULL },
+         { "16", NULL },
+         { "17", NULL },
+         { "18", NULL },
+         { "19", NULL },
+         { "20", NULL },
+         { "21", NULL },
+         { "22", NULL },
+         { "23", NULL },
+         { "24", NULL },
+         { "25", NULL },
+         { "26", NULL },
+         { "27", NULL },
+         { "28", NULL },
+         { "29", NULL },
+         { "30", NULL },
+         { "31", NULL },
+         { "32", NULL },
+         { NULL, NULL },
+      },
+      "32"
+   },
+   {
+      "melonds_jit_branch_optimisations",
+      "JIT Branch Optimisations",
+      NULL,
+      NULL,
+      NULL,
+      "cpu",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "melonds_jit_literal_optimisations",
+      "JIT Literal Optimisations",
+      NULL,
+      NULL,
+      NULL,
+      "cpu",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "melonds_jit_fast_memory",
+      "JIT Fast Memory",
+      NULL,
+      NULL,
+      NULL,
+      "cpu",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
+};
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,        /* RETRO_LANGUAGE_JAPANESE */
+   NULL,        /* RETRO_LANGUAGE_FRENCH */
+   NULL,        /* RETRO_LANGUAGE_SPANISH */
+   NULL,        /* RETRO_LANGUAGE_GERMAN */
+   NULL,        /* RETRO_LANGUAGE_ITALIAN */
+   NULL,        /* RETRO_LANGUAGE_DUTCH */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,        /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,        /* RETRO_LANGUAGE_KOREAN */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,        /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,        /* RETRO_LANGUAGE_POLISH */
+   NULL,        /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,        /* RETRO_LANGUAGE_ARABIC */
+   NULL,        /* RETRO_LANGUAGE_GREEK */
+   NULL,        /* RETRO_LANGUAGE_TURKISH */
+   NULL,        /* RETRO_LANGUAGE_SLOVAK */
+   NULL,        /* RETRO_LANGUAGE_PERSIAN */
+   NULL,        /* RETRO_LANGUAGE_HEBREW */
+   NULL,        /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,        /* RETRO_LANGUAGE_FINNISH */
+   NULL,        /* RETRO_LANGUAGE_INDONESIAN */
+   NULL,        /* RETRO_LANGUAGE_SWEDISH */
+   NULL,        /* RETRO_LANGUAGE_UKRAINIAN */
+   NULL,        /* RETRO_LANGUAGE_CZECH */
+   NULL,        /* RETRO_LANGUAGE_CATALAN_VALENCIA */
+   NULL,        /* RETRO_LANGUAGE_CATALAN */
+};
+#endif
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
+{
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
+
+   if (!environ_cb || !categories_supported)
+      return;
+
+   *categories_supported = false;
+
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_v2_intl core_options_intl;
+
+      core_options_intl.us    = &options_us;
+      core_options_intl.local = NULL;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = options_intl[language];
+
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
+#else
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
+#endif
+   }
+   else
+   {
+      size_t i, j;
+      size_t option_index              = 0;
+      size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
+
+      /* Determine total number of options */
+      while (true)
+      {
+         if (option_defs_us[num_options].key)
+            num_options++;
+         else
+            break;
+      }
+
+      if (version >= 1)
+      {
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
+
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
+            while (true)
+            {
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
+               else
+                  break;
+            }
+
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
+            {
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
+
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
+
+               /* Values must be copied individually... */
+               while (option_values->value)
+               {
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
+               }
+            }
+         }
+
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
+      }
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      }
+
+error:
+      /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libretro/libretro_core_options_intl.h
+++ b/src/libretro/libretro_core_options_intl.h
@@ -1,0 +1,91 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
* Updated core options to v2.
* Not really needed here but updated "libretro.h".
* Added a "Use Firmware Settings" option, for users who prefer to use language and username from the DS firmware.
* Added a "Language" option.
* Default username is now the one set in the frontend, if emtpy it will fall back to "melonDS" just like before.
* Reduced the "JIT Block Size" max from "100" to "32", as it's the max allowed by the emulator anyway: https://github.com/libretro/melonDS/blob/6a03f3f11a729dbf698ec53954c735a0680aca01/src/ARMJIT.cpp#L579-L580
* Adjusted the screen gap to a few fixed values to match standalone (but if people prefer, I'll re-add the 0 -> 192 options): 
![image](https://user-images.githubusercontent.com/33353403/193836718-e8c893a6-6329-4ca1-a3a3-e98e6afcba43.png)
* Made "Mouse" the new default for "Touch Mode", makes more sense than having it disabled IMO.
* Show/hide OpenGL and JIT options depending on if they're enabled/disabled and Hybrid options depending on the selected layout.

I think that's it, please feel free to adjust and/or complete the options descriptions.