### PR TITLE
Add better mic input

### DIFF
--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -250,6 +250,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
 #endif
    {
+      "melonds_mic_input",
+      "Microphone Input",
+      NULL,
+      "Choose the type of noise that will be used as microphone input.",
+      NULL,
+      "audio",
+      {
+         { "Blow Noise",  NULL },
+         { "White Noise", NULL },
+         { NULL, NULL },
+      },
+      "Blow Noise"
+   },
+   {
       "melonds_audio_bitrate",
       "Audio Bitrate",
       NULL,


### PR DESCRIPTION
This PR adds a core option that lets you choose between a blow noise (from https://github.com/libretro/melonDS/blob/master/src/frontend/mic_blow.h) and the previous randomly generated white noise.

This is an often requested feature because the current white noise doesn't work in some games (the 2 Zelda games, the balloon mini-game in MKDS and probably many others).

I hesitated to remove the white noise completely, but I haven't tested a lot of games so maybe in some cases it'll work better than the blow noise, idk, so IMO it's best to leave it as a choice :)

I wanted to add a 3rd option that'd let you use a .wav file but it required SDL2 to make sure the .wav was in the correct format (see https://github.com/libretro/melonDS/issues/174#issuecomment-1324942449 for more details) and I couldn't make a working alternative because of my limited skills. Would be great if someone else could implement it at some point tho!